### PR TITLE
corrected underscore link + added https (required currently)

### DIFF
--- a/flickr.html
+++ b/flickr.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="http://documentcloud.github.com/underscore/underscore-min.js"></script>
+<script src="http://underscorejs.org/underscore-min.js"></script>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
 <meta charset=utf-8 />
 <title>JS Bin</title>
@@ -35,7 +35,7 @@ $("form").submit(function() {
   var setID = $("#set-id").val();
   if(!apiKey) {alert("No API Key");}
   if(!setID) {alert("No Set ID");}
-  $.ajax({url: "http://api.flickr.com/services/rest/?method=flickr.photosets.getPhotos&format=json", data: {photoset_id: setID, extras:size, api_key:apiKey}, success: printResults, dataType: "jsonp", 'jsonp': 'jsoncallback' });
+  $.ajax({url: "https://api.flickr.com/services/rest/?method=flickr.photosets.getPhotos&format=json", data: {photoset_id: setID, extras:size, api_key:apiKey}, success: printResults, dataType: "jsonp", 'jsonp': 'jsoncallback' });
   
   return false;
   


### PR DESCRIPTION
https is now required for Flickr api calls. 
